### PR TITLE
Bugfix/token

### DIFF
--- a/lib/tpquery.js
+++ b/lib/tpquery.js
@@ -17,7 +17,8 @@ TPQuery.prototype.entities = [
   'Projects', 'Features', 'Releases', 'Iterations', 'Requests',
   'CustomFields', 'Bugs', 'Tasks', 'TestCases', 'Times',
   'Impediments', 'Assignments', 'Attachments', 'Comments',
-  'UserStories', 'Roles', 'GeneralUsers', 'Context', 'EntityState'
+  'UserStories', 'Roles', 'GeneralUsers', 'Context', 'EntityState',
+  'TeamIterations'
 ]
 
 TPQuery.prototype.get = function(entity) {

--- a/lib/tpquery.js
+++ b/lib/tpquery.js
@@ -8,7 +8,7 @@ function TPQuery(baseUrl, token) {
   this.baseUrl = baseUrl
   this.opts = {
     json: true,
-    qs: {},
+    qs: { token: token },
     headers: { Authorization: 'Basic '+ token }
   }
 }


### PR DESCRIPTION
The Authorization header data is only working with a decrypted username+password but if you are working with an API token, you have to add this as a query string.

http://dev.targetprocess.com/rest/authentication -> Token Authentication
