### PR TITLE
Add `convertJsonDates` option + housekeeping + updated dependencies + version 1.3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.idea/*

--- a/README.md
+++ b/README.md
@@ -145,6 +145,18 @@ tp('Tasks').
 })
 ```
 
+## Hint
+Some of these methods will return deeply nested objects. If you want to debug them it's recommended to use node's [`util.inspect()`](https://nodejs.org/api/util.html#util_util_inspect_object_options)
+```
+var util = require('util');
+tp('Tasks')
+  .take(10)
+  .then(function(err, tasks) {
+    console.log(util.inspect(tasks, { showHidden: true, depth: null }));
+  }
+)
+```
+
 ## Changelog
 
 ### Version 1.3.0

--- a/README.md
+++ b/README.md
@@ -144,35 +144,21 @@ tp('Tasks').
 })
 ```
 
-#### Nested JSON objects
-It may happen that the following code:
-```javascript
+## Changelog
+
+### 1.3
+Starting from this version all date-values will be converted to Date-Objects
+``` javascript
+
 tp('Tasks')
-  .take(1)
-  .pluck('CustomFields')
-  .then(function(err, tasks) {
-    console.log('my tasks', tasks)
-  }
-)
-```
-will return a lot of nested JSON objects:
-```bash
-my tasks [ { ResourceType: 'Task',
-    Id: 3631,
-    Project: { ResourceType: 'Project', Id: 4026, Process: [Object] },
-    CustomFields: [ [Object], [Object], [Object], [Object], [Object] ] } ]
-```
-The returned object `tasks` here is a JavaScript object. In order to convert it into JSON string, use [`JSON.stringify()`](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify):
-```javascript
-tp('Tasks')
-  .take(1)
-  .pluck('CustomFields')
-  .then(function(err, tasks) {
-    console.log('my tasks', JSON.stringify(tasks))  // changed here
-  }
-)
-```
-and now it returns:
-```bash
-my tasks [{"ResourceType":"Task","Id":3631,"Project":{"ResourceType":"Project","Id":4026,"Process":{"Id":5,"Name":"AIScrum"}},"CustomFields":[{"Name":"Component","Type":"DropDown","Value":null},{"Name":"trac","Type":"Number","Value":null},{"Name":"Job","Type":"DropDown","Value":null},{"Name":"Resolution","Type":"DropDown","Value":null},{"Name":"Domain","Type":"DropDown","Value":null}]}]
+  .sortByDesc('StartDate')
+  .take(10)
+  .pluck('Name', 'StartDate')
+  .then((err, tasks) => {
+    if (err)  return console.log('err', err);
+    console.log('Found:', tasks.length);
+    tasks.forEach(function(t) {
+      console.log( t.Id + ' :: ' + (t.StartDate.getMonth() + 1) + "-" + t.StartDate.getDate() + "-" + t.StartDate.getFullYear() );
+    })
+  });
 ```

--- a/README.md
+++ b/README.md
@@ -8,12 +8,13 @@ In your NodeJS program, add:
 
 ``` javascript
 var tp = require('tp-api')({
-           domain:   // your domain here; eg: 'fullscreen.tpondemand.com'
-           username: // your username; eg: 'paul@fullscreen.net'
-           password: // your password
-           version:  // Optional API version - defaults to 1
-           protocol: // Optional protocol - defaults to https
-         })
+ domain:   // your domain here; eg: 'fullscreen.tpondemand.com'
+ username: // your username; eg: 'paul@fullscreen.net'
+ password: // your password
+ version:  // Optional API version - defaults to 1
+ protocol: // Optional protocol - defaults to https,
+ convertJsonDates: true // Optional convert all dates ((string) `/Date(1467210530000+0200)/`) returned by API to JS Date-Objects
+})
 
 tp('Tasks')
   .take(5)
@@ -146,19 +147,27 @@ tp('Tasks').
 
 ## Changelog
 
-### 1.3
-Starting from this version all date-values will be converted to Date-Objects
+### Version 1.3.0
+Starting from this version you can return real [Date-Objects](https://developer.mozilla.org/de/docs/Web/JavaScript/Reference/Global_Objects/Date).
 ``` javascript
-
+var tp = require('tp-api')({
+  domain: 'domain.tld',
+  token: 'abc'
+  convertJsonDates: true
+});
 tp('Tasks')
-  .sortByDesc('StartDate')
-  .take(10)
+  .take(3)
   .pluck('Name', 'StartDate')
   .then((err, tasks) => {
     if (err)  return console.log('err', err);
-    console.log('Found:', tasks.length);
     tasks.forEach(function(t) {
-      console.log( t.Id + ' :: ' + (t.StartDate.getMonth() + 1) + "-" + t.StartDate.getDate() + "-" + t.StartDate.getFullYear() );
+      console.log( t.Id + ' :: ' + (t.StartDate.getMonth() + 1) + '-' + t.StartDate.getDate() + '-' + t.StartDate.getFullYear() + ' :: ' + t.Name );
+      /*
+        Outputs:
+        85299 :: 12-8-2015 :: Task 1
+        100853 :: 6-14-2016 :: Task 2
+        85708 :: 1-4-2016 :: Task 3
+       */
     })
   });
 ```

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ tp('Tasks').
 ## Changelog
 
 ### Version 1.3.0
-Starting from this version you can return real [Date-Objects](https://developer.mozilla.org/de/docs/Web/JavaScript/Reference/Global_Objects/Date).
+Starting from this version you can return real [Date-Objects](https://developer.mozilla.org/de/docs/Web/JavaScript/Reference/Global_Objects/Date) if `convertJsonDates` is set to `true`
 ``` javascript
 var tp = require('tp-api')({
   domain: 'domain.tld',

--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-var request = require('request')
 var _ = require('lodash')
 var TPQuery = require('./lib/tpquery')
 var TPEntity= require('./lib/tpentity')
@@ -17,14 +16,8 @@ function configure(opts) {
     throw new Error('A TargetProcess domain is required')
   }
 
-  var version = opts.version || 1
-  var domain = opts.domain
-  var token = opts.token
-  var protocol = opts.protocol || 'https'
-  var urlRoot = protocol + '://'+domain+'/api/v'+version
-
   return function(entity, id) {
-    var collection = new TPQuery(urlRoot, token)
+    var collection = new TPQuery(opts)
       , model
 
     if (entity) { collection.get(entity) }

--- a/lib/tpentity.js
+++ b/lib/tpentity.js
@@ -44,7 +44,7 @@ TPEntity.prototype.setState = function(stateName, cb) {
     uri: this.baseUrl + '/EntityStates',
     method: 'GET',
     // force build a query for our current entity state
-    qs: { 
+    qs: {
       where: 'Id eq ' + this.EntityState.Id,
       include: '[NextStates]'
     },
@@ -78,6 +78,7 @@ TPEntity.prototype.sync = function(data){
  * @return {Object} TPEntity
  */
 TPEntity.prototype.then = function(opts, cb) {
+  if(!cb) { cb = noop }
   opts.json = _.extend({}, opts.json || {})
   if( this.Id ) {
     // mixing in id so TP will be able to get the right object
@@ -87,12 +88,10 @@ TPEntity.prototype.then = function(opts, cb) {
   var that = this
   TPSync(options, function(err, data){
     if( err ) {
-      return err;
+      return cb(err);
     }
     that.sync(data);
-    if( cb ) {
-      cb(err, data);
-    }  
+    cb(err, data);
   });
 }
 

--- a/lib/tpentity.js
+++ b/lib/tpentity.js
@@ -13,6 +13,13 @@ function TPEntity(data, options) {
   }
 }
 
+TPEntity.prototype.fetch = function(cb) {
+  this.then({
+    method: 'GET',
+    uri: this.opts.uri + '/' + this.Id
+  }, cb)
+}
+
 TPEntity.prototype.create = function(data, cb) {
   this.then({
     json: data,

--- a/lib/tpquery.js
+++ b/lib/tpquery.js
@@ -4,12 +4,18 @@ var _ = require('lodash')
 
 // TP Entity Query
 // ----------------------
-function TPQuery(baseUrl, token) {
-  this.baseUrl = baseUrl
+function TPQuery(opts) {
+  this.version = opts.version || 1
+  this.domain = opts.domain
+  this.token = opts.token
+  this.protocol = opts.protocol || 'https'
+  this.baseUrl = this.protocol + '://' + this.domain + '/api/v' + this.version
   this.opts = {
-    json: true,
-    qs: { token: token },
-    headers: { Authorization: 'Basic '+ token }
+    convertJsonDates: opts.convertJsonDates,
+    qs: { token: this.token },
+    headers: {
+      Authorization: 'Basic '+ this.token
+    }
   }
 }
 
@@ -23,7 +29,6 @@ TPQuery.prototype.entities = [
 
 TPQuery.prototype.get = function(entity) {
   this.opts = _.extend({}, this.opts, {
-    json: true,
     uri: this.baseUrl+'/'+entity
   })
   return this;
@@ -89,7 +94,6 @@ TPQuery.prototype.append = function() {
  */
 TPQuery.prototype.then = function(cb) {
   var opts = this.opts
-  var that = this
   TPSync(opts, function(err, data){
     cb(err, data);
   })

--- a/lib/tpquery.js
+++ b/lib/tpquery.js
@@ -67,7 +67,7 @@ TPQuery.prototype.sortBy = function(property) {
 // ----------------------------------------------------------------------------
 /**
  * Simple callback structure for fetching queries
- * @param  {Function} cb 
+ * @param  {Function} cb
  */
 TPQuery.prototype.then = function(cb) {
   var opts = this.opts

--- a/lib/tpquery.js
+++ b/lib/tpquery.js
@@ -132,4 +132,17 @@ TPQuery.prototype.comment = function(entityId, comment, cb) {
   }, cb)
 }
 
+TPQuery.prototype.tag = function(entityId, tags, cb) {
+  var that = this
+  var commentEntity = new TPEntity({}, that.opts)
+  commentEntity.then({
+    json: {
+      Id: entityId,
+      Tags: tags
+    },
+    uri: that.baseUrl + '/UserStories',
+    method: 'POST'
+  }, cb)
+}
+
 module.exports = TPQuery

--- a/lib/tpsync.js
+++ b/lib/tpsync.js
@@ -1,9 +1,36 @@
-request = require('request')
+var request = require('request');
+var dotNetDate = require('json-dotnet-date')({
+  useInputTimeZone: true
+});
+
+var jsonReviver = function(key, value) {
+  if (dotNetDate.testStr(value)) {
+    return dotNetDate.parse(value);
+  }
+  return value;
+}
 
 function TPSync(opts, cb) {
-  return request(opts, function(err, res, json) {
-    if (typeof json === 'string') {
-      err = new Error("Couldn't find resource at "+ opts.uri)
+
+  // Remap options, because we want to use our own JSON.parse
+  if (opts.json) {
+    opts.headers['content-type'] = 'application/json';
+    opts.json = false;
+  }
+
+  return request(opts, function(err, res, body) {
+    // TP returns XML in case of errors. Yay. ¯\_(ツ)_/¯
+    if (body.indexOf('<Error>') === 0) {
+      err = new Error('Couldn\'t find resource at ' + opts.uri + ' ' + JSON.stringify(opts.qs));
+      cb(err, null);
+      return;
+    }
+
+    var json = null;
+    try {
+      json = JSON.parse(body, jsonReviver);
+    } catch (e) {
+      err = new Error("Can't parse JSON: \n" + body);
     }
 
     if (json && json.Error) {
@@ -13,10 +40,9 @@ function TPSync(opts, cb) {
     if (typeof err === 'string') {
       err = new Error(err)
     }
-    
+
     // normalize reponse data
     if (json && json.Items) { json = json.Items }
-    
     cb(err, (err) ? null : json)
   })
 }

--- a/lib/tpsync.js
+++ b/lib/tpsync.js
@@ -11,12 +11,9 @@ var jsonReviver = function(key, value) {
 }
 
 function TPSync(opts, cb) {
-
-  // Remap options, because we want to use our own JSON.parse
-  if (opts.json) {
-    opts.headers['content-type'] = 'application/json';
-    opts.json = false;
-  }
+  // (Re)set options for request
+  opts.json = false;
+  opts.headers['content-type'] = 'application/json';
 
   return request(opts, function(err, res, body) {
     // TP returns XML in case of errors. Yay. ¯\_(ツ)_/¯
@@ -28,7 +25,7 @@ function TPSync(opts, cb) {
 
     var json = null;
     try {
-      json = JSON.parse(body, jsonReviver);
+      json = JSON.parse(body, opts.convertJsonDates ? jsonReviver : null);
     } catch (e) {
       err = new Error("Can't parse JSON: \n" + body);
     }

--- a/lib/tpsync.js
+++ b/lib/tpsync.js
@@ -13,10 +13,10 @@ function TPSync(opts, cb) {
     if (typeof err === 'string') {
       err = new Error(err)
     }
-    
+
     // normalize reponse data
     if (json && json.Items) { json = json.Items }
-    
+
     cb(err, (err) ? null : json)
   })
 }

--- a/package.json
+++ b/package.json
@@ -16,11 +16,11 @@
   "license": "BSD",
   "dependencies": {
     "json-dotnet-date": "^0.1.7",
-    "lodash": "~2.4.1",
-    "request": "~2.27.0"
+    "lodash": "~4.16.4",
+    "request": "~2.76.0"
   },
   "devDependencies": {
-    "mocha": "~1.17.0"
+    "mocha": "~3.1.2"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tp-api",
-  "version": "1.2.1",
+  "version": "1.3",
   "description": "An API to access entities from TargetProcess",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tp-api",
-  "version": "1.3",
+  "version": "1.3.0",
   "description": "An API to access entities from TargetProcess",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -14,8 +14,9 @@
   ],
   "license": "BSD",
   "dependencies": {
-    "request": "~2.27.0",
-    "lodash": "~2.4.1"
+    "json-dotnet-date": "^0.1.7",
+    "lodash": "~2.4.1",
+    "request": "~2.27.0"
   },
   "devDependencies": {
     "mocha": "~1.17.0"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "contributors": [
     "Ryan Barry <azaeres@gmail.com> (https://github.com/ryancbarry)",
     "Jeff Uyeno <jeff.uyeno@gmail.com> (https://github.com/jeffuyeno)",
-    "Julian Kleinhans <def@kj187.de> (http://blog.kj187.de)"
+    "Julian Kleinhans <def@kj187.de> (http://blog.kj187.de)",
+    "Mathias Schopmans <mathias.schopmans@aoe.com> (http://aoe.com)"
   ],
   "license": "BSD",
   "dependencies": {


### PR DESCRIPTION
### Version 1.3.0

Starting from this version you can return real [Date-Objects](https://developer.mozilla.org/de/docs/Web/JavaScript/Reference/Global_Objects/Date) if `convertJsonDates` is set to `true`

``` javascript
var tp = require('tp-api')({
  domain: 'domain.tld',
  token: 'abc'
  convertJsonDates: true
});

tp('Tasks')
  .take(3)
  .pluck('Name', 'StartDate')
  .then((err, tasks) => {
    if (err)  return console.log('err', err);
    tasks.forEach(function(t) {
      console.log( t.Id + ' :: ' + (t.StartDate.getMonth() + 1) + '-' + t.StartDate.getDate() + '-' + t.StartDate.getFullYear() + ' :: ' + t.Name );
      /*
        Outputs:
        85299 :: 12-8-2015 :: Task 1
        100853 :: 6-14-2016 :: Task 2
        85708 :: 1-4-2016 :: Task 3
       */
    })
  });
```
